### PR TITLE
Avoids number parsing problem version ends with zero: "5.10" -> "5.1"

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -201,7 +201,7 @@ const testVersions = (versions) => {
   })
 }
 
-const argv = require('minimist')(process.argv.slice(2))
+const argv = require('minimist')(process.argv.slice(2), { string: '_' })
 
 const cmds = {
   'ls': () => {


### PR DESCRIPTION
I noticed a parsing error while running tests with version numbers that have 2 digits in the last segment and end with a zero, e.g. `5.10`, `0.10`: 

```
✔ ~/code/autochecker [master|✔]
18:39 $ autochecker 5.10
## Running tests in version 5.1 only
5.1 - copying files
5.1 - writing dockerfile
5.1 - pulling image mhart/alpine-node:5.1
Pulling from mhart/alpine-node
Already exists
Already exists
Already exists
Digest: sha256:7f651616066bb0383f2e0a07fced3fa4af8d312edd6b20096e678e7e2f35e664
Status: Image is up to date for mhart/alpine-node:5.1
5.1 - building image
Step 1 : FROM mhart/alpine-node:5.1
 ---> 4ff593de68a9
<snip />
```

Though invoked with `5.10`, the image for version `5.1` was pulled. Apparently an image for this version exists, though it might not be the version intended. 

Running it with `0.10` it get's fuzzy:

```
✔ ~/code/autochecker [master|✔]
18:43 $ autochecker 0.10
## Running tests in version 0.1 only
0.1 - copying files
0.1 - writing dockerfile
0.1 - pulling image mhart/alpine-node:0.1
Pulling repository docker.io/mhart/alpine-node
undefined
0.1 - building image
Step 1 : FROM mhart/alpine-node:0.1
net.js:617
    throw new TypeError('invalid data');
    ^
<snip />
```

Apparently [minimist by default parses "strings that look like numbers as numbers"](https://www.npmjs.com/package/minimist#var-argv--parseargsargs-opts). 

This PR configures `minimist` to parse unnamed arguments as strings allow users to pick the actual version.

Unfortunately the unit tests on core are broken, though this change only touches `cli.js` and not the core parts under test.
